### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ De Generieke Geo Componenten (GGC) helpen softwareontwikkelaars om snel een kaar
 Deze Angular front-end componenten kunnen in de eigen applicatie geïnstalleerd worden. Hiermee kan de kracht van OpenLayers kaartpresentatie snel en eenvoudig geïmplementeerd worden, gecombineerd met:
 * zoeken op de kaart
 * legenda
-* kaartselectie
+* kaartweergave kiezen
 * toolbar met tekenen, meten en bewerken op de kaart
 
 Binnenkort komen ook extra componenten beschikbaar voor:


### PR DESCRIPTION
In GIS-termen is "kaartlagen selectie" juister, maar helaas minder toegankelijk voor niet-ingewijden.
"Kaartweergave kiezen" focust op functionaliteit.