### PR TITLE
TMS-11213 peerDependenciesMeta/optional fix

### DIFF
--- a/projects/ggc-dataset-tree/package.json
+++ b/projects/ggc-dataset-tree/package.json
@@ -4,8 +4,18 @@
   "peerDependencies": {
     "@angular/common": "^21.0.0",
     "@angular/core": "^21.0.0",
+    "@kadaster/ggc-cesium": "*",
+    "@kadaster/ggc-map": "^1.0.0",
     "bootstrap": ">=4.3.1 <6.0.0",
     "popper.js": "^1.16.1"
+  },
+  "peerDependenciesMeta": {
+    "@kadaster/ggc-cesium": {
+      "optional": true
+    },
+    "@kadaster/ggc-map": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@kadaster/ggc-models": "^1.0.0",

--- a/projects/ggc-legend/package.json
+++ b/projects/ggc-legend/package.json
@@ -3,7 +3,17 @@
   "version": "1.0.0",
   "peerDependencies": {
     "@angular/common": "^21.0.0",
-    "@angular/core": "^21.0.0"
+    "@angular/core": "^21.0.0",
+    "@kadaster/ggc-cesium": "*",
+    "@kadaster/ggc-map": "^1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@kadaster/ggc-cesium": {
+      "optional": true
+    },
+    "@kadaster/ggc-map": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@kadaster/ggc-models": "^1.0.0",

--- a/projects/ggc-search-location/package.json
+++ b/projects/ggc-search-location/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "peerDependencies": {
     "@angular/common": "^21.0.0",
-    "@angular/core": "^21.0.0"
+    "@angular/core": "^21.0.0",
+    "@angular/cdk": "^21.0.0"
   },
   "dependencies": {
     "@kadaster/ggc-models": "^1.0.0",

--- a/projects/ggc-search-location/package.json
+++ b/projects/ggc-search-location/package.json
@@ -4,7 +4,18 @@
   "peerDependencies": {
     "@angular/common": "^21.0.0",
     "@angular/core": "^21.0.0",
-    "@angular/cdk": "^21.0.0"
+    "@angular/cdk": "^21.0.0",
+    "@kadaster/ggc-map": "^1.0.0",
+    "ol": "^10.7.0",
+    "proj4": "^2.8.0"
+  },
+  "peerDependenciesMeta": {
+    "@kadaster/ggc-map": {
+      "optional": true
+    },
+    "ol": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@kadaster/ggc-models": "^1.0.0",

--- a/projects/ggc-search-location/src/lib/search-location/ggc-search-location.component.ts
+++ b/projects/ggc-search-location/src/lib/search-location/ggc-search-location.component.ts
@@ -646,7 +646,9 @@ export class GgcSearchLocationComponent implements OnInit {
 
   private async loadFormatType() {
     if (!this.formatTypeCache) {
-      const module = await import("@kadaster/ggc-map");
+      const module = await import(
+        /* webpackMode: "eager" */ "@kadaster/ggc-map"
+      );
       this.formatTypeCache = module.FormatType;
     }
 

--- a/projects/ggc-search-location/src/lib/search-location/ggc-search-location.component.ts
+++ b/projects/ggc-search-location/src/lib/search-location/ggc-search-location.component.ts
@@ -38,7 +38,6 @@ import {
 import { PdokLocationApiService } from "../service/pdok-location-api.service";
 import { SearchLocationOptions } from "../model/search-location-options.model";
 import { GgcSearchLocationConnectService } from "../service/connect.service";
-import { FormatType } from "@kadaster/ggc-map";
 
 const BTN_SUFFIX = "btn-form-icon";
 
@@ -95,6 +94,7 @@ export class GgcSearchLocationComponent implements OnInit {
   private hasInitialSearchterm = false;
   private result?: PdokLocationApiSearchFeature | SearchComponentEventTypes;
   private readonly searchTerm$ = new BehaviorSubject<string>("");
+  private formatTypeCache: any;
 
   /** De CSS-klasse voor de 'verwijder' knop in het zoekveld. */
   get classClearButton(): string {
@@ -464,6 +464,7 @@ export class GgcSearchLocationComponent implements OnInit {
     if (this.searchLocationOptions?.zoomToResult) {
       const mapService = (await this.connectService.getMapService()) as any;
       if (mapService) {
+        const formatType = await this.loadFormatType();
         if (Array.isArray(feature)) {
           mapService.zoomToGeometryWithZoomOptions(
             JSON.stringify({ type: "Point", coordinates: feature }),
@@ -471,7 +472,7 @@ export class GgcSearchLocationComponent implements OnInit {
               mapIndex: this.searchLocationOptions?.mapIndex,
               fitOptions: { padding: [50, 50, 50, 50] }
             },
-            FormatType.GEOJSON
+            formatType.GEOJSON
           );
         } else if (feature.bbox) {
           mapService.zoomToExtent(feature.bbox, {
@@ -485,7 +486,7 @@ export class GgcSearchLocationComponent implements OnInit {
               mapIndex: this.searchLocationOptions?.mapIndex,
               fitOptions: { padding: [50, 50, 50, 50] }
             },
-            FormatType.GEOJSON
+            formatType.GEOJSON
           );
         }
       }
@@ -502,11 +503,12 @@ export class GgcSearchLocationComponent implements OnInit {
     if (this.searchLocationOptions?.markResult) {
       const mapService = (await this.connectService.getMapService()) as any;
       if (mapService) {
+        const formatType = await this.loadFormatType();
         if (Array.isArray(feature)) {
           mapService.markFeature(
             JSON.stringify({ type: "Point", coordinates: feature }),
             this.searchLocationOptions?.mapIndex,
-            FormatType.GEOJSON
+            formatType.GEOJSON
           );
         } else if (feature?.properties?.href) {
           this.pdokLocationApiService
@@ -517,7 +519,7 @@ export class GgcSearchLocationComponent implements OnInit {
                 mapService.markFeature(
                   JSON.stringify(item.geometry),
                   this.searchLocationOptions?.mapIndex,
-                  FormatType.GEOJSON
+                  formatType.GEOJSON
                 );
               }
             });
@@ -640,5 +642,14 @@ export class GgcSearchLocationComponent implements OnInit {
 
     this.loadCurrentLocation = true;
     this.searchLocationService.getLocation(false);
+  }
+
+  private async loadFormatType() {
+    if (!this.formatTypeCache) {
+      const module = await import("@kadaster/ggc-map");
+      this.formatTypeCache = module.FormatType;
+    }
+
+    return this.formatTypeCache;
   }
 }

--- a/projects/ggc-search-location/src/lib/service/ggc-location.service.spec.ts
+++ b/projects/ggc-search-location/src/lib/service/ggc-location.service.spec.ts
@@ -2,7 +2,6 @@ import { fakeAsync, TestBed, tick } from "@angular/core/testing";
 import { GgcSearchLocationService } from "./ggc-location.service";
 import { GgcSearchLocationConnectService } from "./connect.service";
 import { take } from "rxjs/operators";
-import { Coordinate } from "ol/coordinate";
 
 describe("GgcSearchLocationService", () => {
   let service: GgcSearchLocationService;
@@ -71,7 +70,7 @@ describe("GgcSearchLocationService", () => {
       mapServiceMock.getMap.and.returnValue(mapMock);
       mapServiceMock.getExtraLayer.and.returnValue(layerMock);
 
-      let result: Coordinate | undefined;
+      let result: Array<number> | undefined;
       service
         .getLocationEventsObservable()
         .pipe(take(1))

--- a/projects/ggc-search-location/src/lib/service/ggc-location.service.ts
+++ b/projects/ggc-search-location/src/lib/service/ggc-location.service.ts
@@ -1,16 +1,6 @@
 import { inject, Injectable } from "@angular/core";
-import Feature from "ol/Feature";
-import { Geometry } from "ol/geom";
-import VectorLayer from "ol/layer/Vector";
-import { register } from "ol/proj/proj4";
-import VectorSource from "ol/source/Vector";
-import CircleStyle from "ol/style/Circle";
-import Fill from "ol/style/Fill";
-import Stroke from "ol/style/Stroke";
-import Style from "ol/style/Style";
 import * as proj4x from "proj4";
 import { Observable, Subject, Subscription } from "rxjs";
-import { fromLonLat } from "ol/proj";
 import { GgcSearchLocationConnectService } from "./connect.service";
 import {
   DEFAULT_MAPINDEX,
@@ -53,7 +43,17 @@ export class GgcSearchLocationService {
 
   constructor() {
     proj4.defs("EPSG:28992", defs);
-    register(proj4);
+    this.tryRegisterProj4();
+  }
+
+  private tryRegisterProj4() {
+    import("ol/proj/proj4")
+      .then((olProj4) => {
+        olProj4.register(proj4);
+      })
+      .catch(() => {
+        console.debug("proj4 van OpenLayers niet beschikbaar");
+      });
   }
 
   /**
@@ -86,7 +86,7 @@ export class GgcSearchLocationService {
     if (mapService) {
       const map = mapService.getMap(mapIndex);
       if (map) {
-        this.setGeolocationLayerStyle(mapService, mapIndex);
+        await this.setGeolocationLayerStyle(mapService, mapIndex);
         if (track) {
           if (!this.geolocations.has(mapIndex)) {
             this.geolocations.set(
@@ -156,12 +156,21 @@ export class GgcSearchLocationService {
     mapIndex: string,
     position: GeolocationPosition
   ) {
-    const coordinates = fromLonLat(
-      [position.coords.longitude, position.coords.latitude],
-      "EPSG:28992"
-    );
+    const coordinates = proj4("EPSG:28992", [
+      position.coords.longitude,
+      position.coords.latitude
+    ]);
     this.locationEventsMap.getOrCreateSubject(mapIndex).next(coordinates);
     this.currentLocation.next(coordinates);
+  }
+
+  private async loadOpenLayers() {
+    const Fill = (await import("ol/style/Fill")).default;
+    const Stroke = (await import("ol/style/Stroke")).default;
+    const Style = (await import("ol/style/Style")).default;
+    const CircleStyle = (await import("ol/style/Circle")).default;
+
+    return { Fill, Stroke, Style, CircleStyle };
   }
 
   /**
@@ -170,7 +179,12 @@ export class GgcSearchLocationService {
    * @param mapService - De MapService instantie.
    * @param mapIndex - De index van de kaart waarop de stijl moet worden toegepast.
    */
-  private setGeolocationLayerStyle(mapService: any, mapIndex: string): void {
+  private async setGeolocationLayerStyle(
+    mapService: any,
+    mapIndex: string
+  ): Promise<void> {
+    debugger;
+    const { Fill, Stroke, Style, CircleStyle } = await this.loadOpenLayers();
     const geoLocationStyle = new Style({
       fill: new Fill({
         color: "rgba(0, 115, 149, 0.5)"
@@ -190,11 +204,8 @@ export class GgcSearchLocationService {
         })
       })
     });
-    (
-      mapService.getExtraLayer(
-        this.GEOLOCATION_LAYER_ID,
-        mapIndex
-      ) as VectorLayer<VectorSource<Feature<Geometry>>>
-    )?.setStyle(geoLocationStyle);
+    mapService
+      .getExtraLayer(this.GEOLOCATION_LAYER_ID, mapIndex)
+      ?.setStyle(geoLocationStyle);
   }
 }

--- a/projects/ggc-search-location/src/lib/service/ggc-location.service.ts
+++ b/projects/ggc-search-location/src/lib/service/ggc-location.service.ts
@@ -1,5 +1,4 @@
 import { inject, Injectable } from "@angular/core";
-import { Coordinate } from "ol/coordinate";
 import Feature from "ol/Feature";
 import { Geometry } from "ol/geom";
 import VectorLayer from "ol/layer/Vector";
@@ -20,6 +19,8 @@ import {
 } from "@kadaster/ggc-models";
 
 const proj4 = (proj4x as any).default;
+
+export type Coordinate = Array<number>;
 
 /**
  * Service verantwoordelijk voor het ophalen en beheren van de geografische locatie van de gebruiker.

--- a/projects/ggc-search-location/src/lib/service/ggc-location.service.ts
+++ b/projects/ggc-search-location/src/lib/service/ggc-location.service.ts
@@ -165,10 +165,15 @@ export class GgcSearchLocationService {
   }
 
   private async loadOpenLayers() {
-    const Fill = (await import("ol/style/Fill")).default;
-    const Stroke = (await import("ol/style/Stroke")).default;
-    const Style = (await import("ol/style/Style")).default;
-    const CircleStyle = (await import("ol/style/Circle")).default;
+    const Fill = (await import(/* webpackMode: "eager" */ "ol/style/Fill"))
+      .default;
+    const Stroke = (await import(/* webpackMode: "eager" */ "ol/style/Stroke"))
+      .default;
+    const Style = (await import(/* webpackMode: "eager" */ "ol/style/Style"))
+      .default;
+    const CircleStyle = (
+      await import(/* webpackMode: "eager" */ "ol/style/Circle")
+    ).default;
 
     return { Fill, Stroke, Style, CircleStyle };
   }
@@ -183,7 +188,6 @@ export class GgcSearchLocationService {
     mapService: any,
     mapIndex: string
   ): Promise<void> {
-    debugger;
     const { Fill, Stroke, Style, CircleStyle } = await this.loadOpenLayers();
     const geoLocationStyle = new Style({
       fill: new Fill({


### PR DESCRIPTION
Dit lost het probleem op dat de dependency @kadaster/ggc-cesium nodig is bij het gebruik van de ggc-legend of ggc-dataset-tree (terwijl je alleen een 2D kaart wilt gebruiken). De ggc-cesium en ggc-map zijn toegevoegd als optionele dependencies waardoor het probleem `Failed to resolve import "@kadaster/ggc-cesium"` niet meer voorkomt.