### PR TITLE
TMS-11426 Fix bug dat ValueTemplateDirectiveType.HIDE niet meer werkte

### DIFF
--- a/projects/ggc-feature-info/src/lib/feature-info-display/feature-info-display.component.ts
+++ b/projects/ggc-feature-info/src/lib/feature-info-display/feature-info-display.component.ts
@@ -23,7 +23,7 @@ export class FeatureInfoDisplayComponent implements OnInit, OnChanges {
   type = input<FeatureInfoDisplayType>(FeatureInfoDisplayType.TABLE);
   currentFeature = input<{ [key: string]: any } | null>(null);
   hideEmptyFields = input<boolean>(false);
-  headerValueTemplates = input<Map<string, TemplateRef<any>>>(new Map());
+  headerValueTemplates = input<Map<string, TemplateRef<any> | null>>(new Map());
   contentValueTemplates = input<Map<string, TemplateRef<any>>>(new Map());
   hideEmptyFieldWithKeys = input<string[]>([]);
 

--- a/projects/ggc-feature-info/src/lib/feature-info/ggc-feature-info.component.spec.ts
+++ b/projects/ggc-feature-info/src/lib/feature-info/ggc-feature-info.component.spec.ts
@@ -260,7 +260,7 @@ describe("FeatureInfoWrapperComponent", () => {
     expect(component).toBeDefined();
     expect(component["templates"].length).toBe(5);
     expect(component["customValueTemplates"].size).toBe(3);
-    expect(component["customHeaderValueTemplates"].size).toBe(3);
+    expect(component["customHeaderValueTemplates"].size).toBe(4);
     expect(component["customValueTemplates"].get("status")).toBeDefined();
     expect(component["customValueTemplates"].get("bronhoudernaam")).toEqual(
       component["customValueTemplates"].get("bronhoudercode")
@@ -274,9 +274,9 @@ describe("FeatureInfoWrapperComponent", () => {
     expect(
       component["customHeaderValueTemplates"].get("waarde3")
     ).toBeDefined();
-    expect(
-      component["customHeaderValueTemplates"].get("waarde4")
-    ).not.toBeDefined();
+    const waarde4 = component["customHeaderValueTemplates"].get("waarde4");
+    expect(waarde4).toBeDefined();
+    expect(waarde4).toEqual(null);
     expect(component["customHeaderValueTemplates"].get("waarde1")).not.toEqual(
       component["customHeaderValueTemplates"].get("waarde2")
     );

--- a/projects/ggc-feature-info/src/lib/feature-info/ggc-feature-info.component.ts
+++ b/projects/ggc-feature-info/src/lib/feature-info/ggc-feature-info.component.ts
@@ -144,7 +144,7 @@ export class GgcFeatureInfoComponent
    * Stuurt `FeatureInfoComponentEvent` bij selectie van een object.
    */
   @Output() events = new EventEmitter<FeatureInfoComponentEvent>();
-  protected customHeaderValueTemplates: Map<string, TemplateRef<any>> =
+  protected customHeaderValueTemplates: Map<string, TemplateRef<any> | null> =
     new Map();
   protected customValueTemplates: Map<string, TemplateRef<any>> = new Map();
   protected hideEmptyFieldWithKeys: string[] = [];
@@ -278,7 +278,7 @@ export class GgcFeatureInfoComponent
             this.customValueTemplates.set(templateKey, template.templateRef);
             break;
           case ValueTemplateDirectiveType.HIDE:
-            this.customHeaderValueTemplates.delete(templateKey);
+            this.customHeaderValueTemplates.set(templateKey, null);
             break;
           case ValueTemplateDirectiveType.HIDE_IF_EMPTY:
             if (!this.hideEmptyFieldWithKeys.includes(templateKey)) {


### PR DESCRIPTION
De key moet aanwezig zijn in de map (met value null) zodat deze verborgen kan worden.